### PR TITLE
Add info on return port.

### DIFF
--- a/docs/PYNQ-example.rst
+++ b/docs/PYNQ-example.rst
@@ -98,6 +98,11 @@ Make sure that **mul_test.cpp** is open. Open **Directive** and right click on t
 
 .. image:: https://github.com/KastnerRG/Read_the_docs/raw/master/docs/image/lab0_screenshot/2.png
 
+Also add the below pragma inside the function body to get the **ap_ctrl** to be included in the **s_axilite**. This is not available (as of Vitis HLS 2023.1) in the Insert Directive GUI.
+
+.. code-block:: c++
+	#pragma HLS INTERFACE mode=s_axilite port=return
+
 1.4) Synthesis and export your design
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes #31 

With `#pragma HLS INTERFACE mode=s_axilite port=return`,
![image](https://github.com/KastnerRG/Read_the_docs/assets/33192449/c14a756c-65e3-479e-b053-dab2ab03a69b)

We no longer see the `ap_ctrl` unconnected.
![image](https://github.com/KastnerRG/Read_the_docs/assets/33192449/70a69921-1517-4ddb-a197-f6df9abd6c1b)
