### PR TITLE
Fix bnn python script to successfully run with option 1

### DIFF
--- a/project_files/project5_bnn/python/bnn_mnist.py
+++ b/project_files/project5_bnn/python/bnn_mnist.py
@@ -15,7 +15,7 @@ class BNN_MNIST:
         self.quantize = np.vectorize(self.quantize)
 
         self.adj = lambda x: x*2-1
-        self.adj = np.vectorize(self.adj)
+        self.adj = np.vectorize(self.adj, otypes=[float])
         self.model = np.load("weights/model.npy", allow_pickle=True).item()
         # print(model.keys)
         # dict_keys(['fc1w', 'fc2w', 'fc3w'])


### PR DESCRIPTION
numpy version 2.3.5 vectorize function uses datatype of first element in array to determine which type to use. In the example given, this would be 0 and numpy uses uint8 as the datatype. Since the lambda function for adjust is multiply by 2 and subtracting 1, this results in a value of -1 when the element in the array is 0. -1 is not valid given the datatype uint8 numpy assigned, resulting in an error: "OverflowError: Python integer -1 out of bounds for uint8". 

Setting the datatype to use floats allows for the script to run successfully with an accuracy of 89.39. Given this is an example of a successful BNN, it should be able to run smoothly.